### PR TITLE
fix: inject remote repositories via mojo parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,11 @@ language: java
 sudo: false
 
 jdk:
-  - oraclejdk9
   - openjdk8
+
+cache:
+  directories:
+    - "$HOME/.m2/repository"
 
 script: "mvn clean install -Prun-its"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: java
 sudo: false
+dist: trusty
 
 jdk:
-  - openjdk8
+  - oraclejdk8
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: java
-jdk: oraclejdk8
+sudo: false
+
+jdk:
+  - oraclejdk9
+  - openjdk8
+
 script: "mvn clean install -Prun-its"
+
 branches:
   only:
   - master

--- a/src/it/private-repo-module/pom.xml
+++ b/src/it/private-repo-module/pom.xml
@@ -1,0 +1,51 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.snyk.example</groupId>
+    <artifactId>private-repo-module</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>private repo module</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.snyk</groupId>
+                <artifactId>snyk-maven-plugin</artifactId>
+                    <version>1.2.0</version>
+                <executions>
+                    <execution>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <apiToken>${env.SNYK_API_TOKEN}</apiToken>
+                    <endpoint>${env.SNYK_API_ENDPOINT}</endpoint>
+                    <failOnSeverity>false</failOnSeverity>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>my-cool-private-project-repo</id>
+            <url>https://nexus.snyk.io/project-repo</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>my-cool-private-plugin-repo</id>
+            <url>https://nexus.snyk.io/plugin-repo</url>
+        </pluginRepository>
+    </pluginRepositories>
+</project>

--- a/src/it/private-repo-module/verify.bsh
+++ b/src/it/private-repo-module/verify.bsh
@@ -1,0 +1,17 @@
+/*
+ * verifying that the private-repo-module integration test runs as expected
+ */
+
+import java.io.*;
+import org.codehaus.plexus.util.*;
+
+String log = FileUtils.fileRead( new File( basedir, "build.log" ) );
+
+if(!log.contains("[DEBUG] Remote project repository: my-cool-private-project-repo (https://nexus.snyk.io/project-repo, default, releases+snapshots)")) {
+    throw new Exception("Missing project repository: my-cool-private-project-repo");
+}
+if(!log.contains("[DEBUG] Remote plugin repository: my-cool-private-plugin-repo (https://nexus.snyk.io/plugin-repo, default, releases+snapshots)")) {
+    throw new Exception("Missing project repository: my-cool-private-plugin-repo");
+}
+
+return true;

--- a/src/main/java/io/snyk/maven/plugins/ProjectTraversal.java
+++ b/src/main/java/io/snyk/maven/plugins/ProjectTraversal.java
@@ -16,8 +16,6 @@ import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
 import java.security.InvalidParameterException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -30,13 +28,15 @@ public class ProjectTraversal {
     private MavenProject project;
     private RepositorySystem repoSystem;
     private RepositorySystemSession repoSession;
+    private List<RemoteRepository> remoteRepositories;
 
     private JSONObject tree;
     public JSONObject getTree() { return this.tree; }
 
     public ProjectTraversal(MavenProject project,
                             RepositorySystem repoSystem,
-                            RepositorySystemSession repoSession) {
+                            RepositorySystemSession repoSession,
+                            List<RemoteRepository> remoteRepositories) {
         if(project == null || repoSystem == null || repoSession == null) {
             throw new InvalidParameterException();
         }
@@ -44,6 +44,7 @@ public class ProjectTraversal {
         this.project = project;
         this.repoSystem = repoSystem;
         this.repoSession = repoSession;
+        this.remoteRepositories = remoteRepositories;
 
         try {
             this.collectDependencies();
@@ -61,7 +62,7 @@ public class ProjectTraversal {
 
         CollectRequest collectRequest = new CollectRequest();
         collectRequest.setRoot( new Dependency( artifact, JavaScopes.COMPILE ) );
-        collectRequest.setRepositories( newRepositories() );
+        collectRequest.setRepositories( remoteRepositories );
 
         CollectResult collectResult = repoSystem.collectDependencies( repoSession, collectRequest );
         DependencyNode node = collectResult.getRoot();
@@ -111,19 +112,4 @@ public class ProjectTraversal {
 
         return treeNode;
     }
-
-    private static List<RemoteRepository> newRepositories()
-    {
-        return new ArrayList<>( Arrays.asList( newCentralRepository() ) );
-    }
-
-    private static RemoteRepository newCentralRepository()
-    {
-        return new RemoteRepository.Builder(
-            "central",
-            "default",
-            "http://central.maven.org/maven2/"
-        ).build();
-    }
-
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk-maven-plugin/blob/master/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
This PR fixes issue with unresolved dependencies and private Maven repositories.

#### Any background context you want to provide?
Originally only Maven Central repository was created and configured to resolve dependencies (project or plugin). Now we use builtin Maven parameters injected by Maven plugin manager.

#### What are the relevant tickets?
#28

#### Additional questions
I see some code duplication between `SnykTest.java` and `SnykMonitor.java`, but currently it's not the scope of this ticket, so we can refactor it later.