### PR TITLE
Include provided dependencies into project traversal via config parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The following are elements in the `<configuration></configuration>` section of t
 - **apiToken** (mandatory): The **apiToken** is used to authenticate with the Snyk services. With the API token, the plugin can be configured with it as a system property or environment variable. The token can also be manually added to the pom.xml, although this is not the recommended method. This is mandatory configuration.
 - **failOnSeverity** (optional): Setting **failOnSeverity** to any of the values (`low`, `medium` or `high`) will fail the Maven build if a severity is found at or above what was configured. This configuration is optional, and will be set to `low` if not defined. Setting it to `false` will never fail the build.
 - **org** (optional): The **org** configuration element sets under which of your Snyk organisations the project will be recorded. Leaving out this configuration will record the project under your default organisation.
+- **includeProvidedDependencies** (optional): The **includeProvidedDependencies** configuration element allows to include dependencies with `provided` scope. Default value is `false`.
 
 ## Features
 

--- a/src/main/java/io/snyk/maven/plugins/SnykMonitor.java
+++ b/src/main/java/io/snyk/maven/plugins/SnykMonitor.java
@@ -68,6 +68,9 @@ public class SnykMonitor extends AbstractMojo {
     @Parameter
     private String endpoint = Constants.DEFAULT_ENDPOINT;
 
+    @Parameter
+    private boolean includeProvidedDependencies = false;
+
     private String baseUrl = "";
 
     /**
@@ -110,7 +113,7 @@ public class SnykMonitor extends AbstractMojo {
         remoteRepositories.addAll(remotePluginRepositories);
 
         JSONObject projectTree = new ProjectTraversal(
-                project, repoSystem, repoSession, remoteRepositories).getTree();
+                project, repoSystem, repoSession, remoteRepositories, includeProvidedDependencies).getTree();
         HttpResponse response = sendDataToSnyk(projectTree);
         parseResponse(response);
     }

--- a/src/main/java/io/snyk/maven/plugins/SnykTest.java
+++ b/src/main/java/io/snyk/maven/plugins/SnykTest.java
@@ -23,7 +23,6 @@ import org.json.simple.parser.ParseException;
 
 import java.io.*;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -69,6 +68,9 @@ public class SnykTest extends AbstractMojo {
 
     @Parameter
     private String endpoint = Constants.DEFAULT_ENDPOINT;
+
+    @Parameter
+    private boolean includeProvidedDependencies = false;
 
     private String baseUrl = "";
 
@@ -123,7 +125,7 @@ public class SnykTest extends AbstractMojo {
         remoteRepositories.addAll(remotePluginRepositories);
 
         JSONObject projectTree = new ProjectTraversal(
-                project, repoSystem, repoSession, remoteRepositories).getTree();
+                project, repoSystem, repoSession, remoteRepositories, includeProvidedDependencies).getTree();
 
         HttpResponse response = sendDataToSnyk(projectTree);
         parseResponse(response);


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk-maven-plugin/blob/master/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

 #### What does this PR do?
This PR adds a new configuration parameter to include dependencies with provided scope.
The parameter name is `includeProvidedDependencies` with default value `false`, so we don't break existing behavior.
Example configuration
```
...
configuration>
  <apiToken>${env.MY_SNYK_TOKEN}</apiToken>
  <failOnSeverity>low</failOnSeverity>
  <includeProvidedDependencies>true</includeProvidedDependencies>
</configuration>
...
```

