### PR TITLE
feat: include provided dependencies into project traversal via config parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The following are elements in the `<configuration></configuration>` section of t
 - **apiToken** (mandatory): The **apiToken** is used to authenticate with the Snyk services. With the API token, the plugin can be configured with it as a system property or environment variable. The token can also be manually added to the pom.xml, although this is not the recommended method. This is mandatory configuration.
 - **failOnSeverity** (optional): Setting **failOnSeverity** to any of the values (`low`, `medium` or `high`) will fail the Maven build if a severity is found at or above what was configured. This configuration is optional, and will be set to `low` if not defined. Setting it to `false` will never fail the build.
 - **org** (optional): The **org** configuration element sets under which of your Snyk organisations the project will be recorded. Leaving out this configuration will record the project under your default organisation.
+- **includeProvidedDependencies** (optional): The **includeProvidedDependencies** configuration element allows to include dependencies with `provided` scope. Default value is `false`.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The following are elements in the `<configuration></configuration>` section of t
 - **apiToken** (mandatory): The **apiToken** is used to authenticate with the Snyk services. With the API token, the plugin can be configured with it as a system property or environment variable. The token can also be manually added to the pom.xml, although this is not the recommended method. This is mandatory configuration.
 - **failOnSeverity** (optional): Setting **failOnSeverity** to any of the values (`low`, `medium` or `high`) will fail the Maven build if a severity is found at or above what was configured. This configuration is optional, and will be set to `low` if not defined. Setting it to `false` will never fail the build.
 - **org** (optional): The **org** configuration element sets under which of your Snyk organisations the project will be recorded. Leaving out this configuration will record the project under your default organisation.
-- **includeProvidedDependencies** (optional): The **includeProvidedDependencies** configuration element allows to include dependencies with `provided` scope. Default value is `false`.
+- **includeProvidedDependencies** (optional): The **includeProvidedDependencies** configuration element allows to include dependencies with `provided` scope. Default value is `true`.
 
 ## Features
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>io.snyk</groupId>
   <artifactId>snyk-maven-plugin</artifactId>
-  <version>1.2.1</version>
+  <version>1.2.2</version>
   <packaging>maven-plugin</packaging>
 
   <name>Snyk.io Maven Plugin</name>

--- a/src/it/multi-module/pom.xml
+++ b/src/it/multi-module/pom.xml
@@ -36,7 +36,7 @@
             <plugin>
                 <groupId>io.snyk</groupId>
                 <artifactId>snyk-maven-plugin</artifactId>
-                  <version>1.2.1</version>
+                  <version>1.2.2</version>
                 <executions>
                     <execution>
                         <id>snyk-test</id>

--- a/src/it/private-repo-module/pom.xml
+++ b/src/it/private-repo-module/pom.xml
@@ -18,7 +18,7 @@
             <plugin>
                 <groupId>io.snyk</groupId>
                 <artifactId>snyk-maven-plugin</artifactId>
-                    <version>1.2.1</version>
+                    <version>1.2.2</version>
                 <executions>
                     <execution>
                         <phase>test</phase>

--- a/src/it/single-module/pom.xml
+++ b/src/it/single-module/pom.xml
@@ -37,7 +37,7 @@
             <plugin>
                 <groupId>io.snyk</groupId>
                 <artifactId>snyk-maven-plugin</artifactId>
-                    <version>1.2.1</version>
+                    <version>1.2.2</version>
                 <executions>
                     <execution>
                         <phase>test</phase>

--- a/src/main/java/io/snyk/maven/plugins/ProjectTraversal.java
+++ b/src/main/java/io/snyk/maven/plugins/ProjectTraversal.java
@@ -14,12 +14,17 @@ import org.eclipse.aether.graph.DependencyNode;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.util.artifact.JavaScopes;
 import org.eclipse.aether.util.graph.selector.AndDependencySelector;
+import org.eclipse.aether.util.graph.selector.ExclusionDependencySelector;
+import org.eclipse.aether.util.graph.selector.OptionalDependencySelector;
 import org.eclipse.aether.util.graph.selector.ScopeDependencySelector;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
 import java.security.InvalidParameterException;
 import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 
 /**
  * Created by dror on 16/01/2017.
@@ -69,7 +74,10 @@ public class ProjectTraversal {
         );
 
         if (includeProvidedDependencies) {
-            session.setDependencySelector(new AndDependencySelector(new ScopeDependencySelector(JavaScopes.PROVIDED)));
+            session.setDependencySelector(new AndDependencySelector(new ScopeDependencySelector(asList(JavaScopes.COMPILE, JavaScopes.PROVIDED),
+                                                                                                singletonList(JavaScopes.TEST)),
+                                                                    new OptionalDependencySelector(),
+                                                                    new ExclusionDependencySelector()));
         }
 
         CollectRequest collectRequest = new CollectRequest();

--- a/src/main/java/io/snyk/maven/plugins/SnykMonitor.java
+++ b/src/main/java/io/snyk/maven/plugins/SnykMonitor.java
@@ -68,6 +68,9 @@ public class SnykMonitor extends AbstractMojo {
     @Parameter
     private String endpoint = Constants.DEFAULT_ENDPOINT;
 
+    @Parameter
+    private boolean includeProvidedDependencies = false;
+
     private String baseUrl = "";
 
     /**
@@ -110,7 +113,7 @@ public class SnykMonitor extends AbstractMojo {
         remoteRepositories.addAll(remotePluginRepositories);
 
         JSONObject projectTree = new ProjectTraversal(
-                project, repoSystem, repoSession, remoteRepositories).getTree();
+                project, repoSystem, repoSession, remoteRepositories, includeProvidedDependencies).getTree();
         HttpResponse response = sendDataToSnyk(projectTree);
         parseResponse(response);
     }

--- a/src/main/java/io/snyk/maven/plugins/SnykMonitor.java
+++ b/src/main/java/io/snyk/maven/plugins/SnykMonitor.java
@@ -69,7 +69,7 @@ public class SnykMonitor extends AbstractMojo {
     private String endpoint = Constants.DEFAULT_ENDPOINT;
 
     @Parameter
-    private boolean includeProvidedDependencies = false;
+    private boolean includeProvidedDependencies = true;
 
     private String baseUrl = "";
 

--- a/src/main/java/io/snyk/maven/plugins/SnykTest.java
+++ b/src/main/java/io/snyk/maven/plugins/SnykTest.java
@@ -70,7 +70,7 @@ public class SnykTest extends AbstractMojo {
     private String endpoint = Constants.DEFAULT_ENDPOINT;
 
     @Parameter
-    private boolean includeProvidedDependencies = false;
+    private boolean includeProvidedDependencies = true;
 
     private String baseUrl = "";
 

--- a/src/main/java/io/snyk/maven/plugins/SnykTest.java
+++ b/src/main/java/io/snyk/maven/plugins/SnykTest.java
@@ -23,7 +23,6 @@ import org.json.simple.parser.ParseException;
 
 import java.io.*;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -69,6 +68,9 @@ public class SnykTest extends AbstractMojo {
 
     @Parameter
     private String endpoint = Constants.DEFAULT_ENDPOINT;
+
+    @Parameter
+    private boolean includeProvidedDependencies = false;
 
     private String baseUrl = "";
 
@@ -123,7 +125,7 @@ public class SnykTest extends AbstractMojo {
         remoteRepositories.addAll(remotePluginRepositories);
 
         JSONObject projectTree = new ProjectTraversal(
-                project, repoSystem, repoSession, remoteRepositories).getTree();
+                project, repoSystem, repoSession, remoteRepositories, includeProvidedDependencies).getTree();
 
         HttpResponse response = sendDataToSnyk(projectTree);
         parseResponse(response);


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk-maven-plugin/blob/master/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

 #### What does this PR do?
This PR adds a new configuration parameter to include dependencies with provided scope.
The parameter name is `includeProvidedDependencies` with default value `true`, so we don't break existing behavior.
Example configuration
```
...
configuration>
  <apiToken>${env.MY_SNYK_TOKEN}</apiToken>
  <failOnSeverity>low</failOnSeverity>
  <includeProvidedDependencies>false</includeProvidedDependencies>
</configuration>
...
```
