### PR TITLE
fix: plexus utils dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,12 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
       <version>${mavenVersion}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-utils</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <mavenVersion>3.5.0</mavenVersion>
+    <mavenVersion>3.1.0</mavenVersion>
     <aetherVersion>1.1.0</aetherVersion>
   </properties>
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk-maven-plugin/blob/master/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

 #### What does this PR do?
Partially revert of #53. We still use `plexus-utils` without vulnerabilities, but don't update `maven-core` because of breaking changes.

