### PR TITLE
fix: missing package name for license vulns

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The Snyk Maven plugin tests and monitors your Maven dependencies.
         <plugin>
             <groupId>io.snyk</groupId>
             <artifactId>snyk-maven-plugin</artifactId>
-            <version>1.2.1</version>
+            <version>1.2.5</version>
             <executions>
                 <execution>
                     <id>snyk-test</id>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>io.snyk</groupId>
   <artifactId>snyk-maven-plugin</artifactId>
-  <version>1.2.4</version>
+  <version>1.2.5</version>
   <packaging>maven-plugin</packaging>
 
   <name>Snyk.io Maven Plugin</name>

--- a/src/it/license-issues-module/pom.xml
+++ b/src/it/license-issues-module/pom.xml
@@ -38,6 +38,7 @@
                 <configuration>
                     <apiToken>${env.SNYK_API_TOKEN}</apiToken>
                     <endpoint>${env.SNYK_API_ENDPOINT}</endpoint>
+                    <org>${env.SNYK_ORG_ID}</org>
                     <failOnSeverity>false</failOnSeverity>
                 </configuration>
             </plugin>

--- a/src/it/license-issues-module/pom.xml
+++ b/src/it/license-issues-module/pom.xml
@@ -1,0 +1,46 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.snyk.example</groupId>
+    <artifactId>license-issues-module</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>license issues module</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax.faces</groupId>
+            <artifactId>jsf-impl</artifactId>
+            <version>1.2-20</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.snyk</groupId>
+                <artifactId>snyk-maven-plugin</artifactId>
+                    <version>${snyk.maven.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <apiToken>${env.SNYK_API_TOKEN}</apiToken>
+                    <endpoint>${env.SNYK_API_ENDPOINT}</endpoint>
+                    <failOnSeverity>false</failOnSeverity>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/license-issues-module/pom.xml
+++ b/src/it/license-issues-module/pom.xml
@@ -15,9 +15,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.faces</groupId>
-            <artifactId>jsf-impl</artifactId>
-            <version>1.2-20</version>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
         </dependency>
     </dependencies>
 

--- a/src/it/license-issues-module/verify.bsh
+++ b/src/it/license-issues-module/verify.bsh
@@ -1,0 +1,18 @@
+/*
+ * verifying that the single-module integration test runs as expected
+ */
+
+import java.io.*;
+import org.codehaus.plexus.util.*;
+
+String log = FileUtils.fileRead( new File( basedir, "build.log" ) );
+
+if(!log.contains("[WARNING] ? low severity vulnerability found on javax.servlet.jsp:jsp-api@2.1")) {
+    throw new Exception("Missing license issue (CDDL-1.1) for javax.servlet.jsp:jsp-api@2.1");
+}
+
+if(!log.contains("[WARNING] ? low severity vulnerability found on javax.servlet:servlet-api@2.5")) {
+    throw new Exception("Missing license issue (CDDL-1.1) for javax.servlet:servlet-api@2.5");
+}
+
+return true;

--- a/src/it/license-issues-module/verify.bsh
+++ b/src/it/license-issues-module/verify.bsh
@@ -1,5 +1,5 @@
 /*
- * verifying that the single-module integration test runs as expected
+ * verifying that the license-issues-module integration test runs as expected
  */
 
 import java.io.*;
@@ -7,12 +7,8 @@ import org.codehaus.plexus.util.*;
 
 String log = FileUtils.fileRead( new File( basedir, "build.log" ) );
 
-if(!log.contains("[WARNING] ? low severity vulnerability found on javax.servlet.jsp:jsp-api@2.1")) {
-    throw new Exception("Missing license issue (CDDL-1.1) for javax.servlet.jsp:jsp-api@2.1");
-}
-
-if(!log.contains("[WARNING] ? low severity vulnerability found on javax.servlet:servlet-api@2.5")) {
-    throw new Exception("Missing license issue (CDDL-1.1) for javax.servlet:servlet-api@2.5");
+if(!log.contains("[WARNING] - info: https://dev.snyk.io/vuln/snyk:lic:maven:junit:junit:EPL-1.0")) {
+    throw new Exception("Missing license issue (EPL-1.0) for junit:junit@4.12");
 }
 
 return true;

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -8,7 +8,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <snyk.maven.plugin.version>1.2.3</snyk.maven.plugin.version>
+                <snyk.maven.plugin.version>1.2.4</snyk.maven.plugin.version>
             </properties>
             <repositories>
                 <repository>

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -8,7 +8,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <snyk.maven.plugin.version>1.2.4</snyk.maven.plugin.version>
+                <snyk.maven.plugin.version>1.2.5</snyk.maven.plugin.version>
             </properties>
             <repositories>
                 <repository>

--- a/src/main/java/io/snyk/maven/plugins/SnykTest.java
+++ b/src/main/java/io/snyk/maven/plugins/SnykTest.java
@@ -157,7 +157,11 @@ public class SnykTest extends AbstractMojo {
      * @throws ParseException
      */
     private HttpResponse sendDataToSnyk(JSONObject projectTree) throws IOException {
-        HttpPost request = new HttpPost(baseUrl + "/api/vuln/maven/?applyPolicy=true");
+        String vulnMavenEndpoint = "/api/vuln/maven/?applyPolicy=true";
+        if (org != null && !org.isEmpty()) {
+            vulnMavenEndpoint += "&org=" + org;
+        }
+        HttpPost request = new HttpPost(baseUrl + vulnMavenEndpoint);
         request.addHeader("authorization", "token " + apiToken);
         request.addHeader("x-is-ci", "false"); // TODO: how do we know this ??
         request.addHeader("content-type", "application/json");

--- a/src/main/java/io/snyk/maven/plugins/SnykTest.java
+++ b/src/main/java/io/snyk/maven/plugins/SnykTest.java
@@ -276,7 +276,7 @@ public class SnykTest extends AbstractMojo {
      */
     private void printVuln(JSONObject vuln) {
         getLog().warn("✗ " + vuln.get("severity") + " severity vulnerability found on " +
-                vuln.get("moduleName") + "@" +
+                vuln.get("packageName") + "@" +
                 vuln.get("version"));
         getLog().warn("- desc: " + vuln.get("title"));
         getLog().warn("- info: " + baseUrl + "/vuln/" + vuln.get("id"));


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk-maven-plugin/blob/master/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

 #### What does this PR do?

This PR fix following issues:
- use field `packageName` instead of `moduleName` because in JSON schema for license vulnerabilities no `moduleName` is defined (only packageName)
- append `org` configuration parameter to URL if it's defined in configuration section
