### PR TITLE
feat: New optional config item, fail build based on count as alternative to severity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The following are elements in the `<configuration></configuration>` section of t
 
 - **apiToken** (mandatory): The **apiToken** is used to authenticate with the Snyk services. With the API token, the plugin can be configured with it as a system property or environment variable. The token can also be manually added to the pom.xml, although this is not the recommended method. This is mandatory configuration.
 - **failOnSeverity** (optional): Setting **failOnSeverity** to any of the values (`low`, `medium` or `high`) will fail the Maven build if a severity is found at or above what was configured. This configuration is optional, and will be set to `low` if not defined. Setting it to `false` will never fail the build.
+- **failOnCount** (optional): Setting **failOnCount** to higher than `0` will fail the Maven build if more vulnerabilities are found. This configuration is optional, and will be set to `0` if not defined.  **failOnSeverity** should be set to false, when using **failOnCount**.
 - **org** (optional): The **org** configuration element sets under which of your Snyk organisations the project will be recorded. Leaving out this configuration will record the project under your default organisation.
 - **includeProvidedDependencies** (optional): The **includeProvidedDependencies** configuration element allows to include dependencies with `provided` scope. Default value is `true`.
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The following are elements in the `<configuration></configuration>` section of t
 
 - **apiToken** (mandatory): The **apiToken** is used to authenticate with the Snyk services. With the API token, the plugin can be configured with it as a system property or environment variable. The token can also be manually added to the pom.xml, although this is not the recommended method. This is mandatory configuration.
 - **failOnSeverity** (optional): Setting **failOnSeverity** to any of the values (`low`, `medium` or `high`) will fail the Maven build if a severity is found at or above what was configured. This configuration is optional, and will be set to `low` if not defined. Setting it to `false` will never fail the build.
-- **failOnCount** (optional): Setting **failOnCount** to higher than `0` will fail the Maven build if more vulnerabilities are found. This configuration is optional, and will be set to `0` if not defined.  **failOnSeverity** should be set to false, when using **failOnCount**.
+- **failOnCount** (optional): Setting **failOnCount** to higher than `0` will fail the Maven build if more vulnerabilities are found. This configuration is optional, and will be set to `0` if not defined.  **failOnSeverity** will overrule and should be set to false, when using **failOnCount**.
 - **org** (optional): The **org** configuration element sets under which of your Snyk organisations the project will be recorded. Leaving out this configuration will record the project under your default organisation.
 - **includeProvidedDependencies** (optional): The **includeProvidedDependencies** configuration element allows to include dependencies with `provided` scope. Default value is `true`.
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>io.snyk</groupId>
   <artifactId>snyk-maven-plugin</artifactId>
-  <version>1.2.5</version>
+  <version>1.2.6</version>
   <packaging>maven-plugin</packaging>
 
   <name>Snyk.io Maven Plugin</name>

--- a/src/main/java/io/snyk/maven/plugins/SnykTest.java
+++ b/src/main/java/io/snyk/maven/plugins/SnykTest.java
@@ -71,6 +71,9 @@ public class SnykTest extends AbstractMojo {
     private String failOnSeverity = "low";
 
     @Parameter
+    private Integer failOnCount = 0;
+
+    @Parameter
     private String endpoint = Constants.DEFAULT_ENDPOINT;
 
     @Parameter
@@ -270,6 +273,11 @@ public class SnykTest extends AbstractMojo {
                 msg +=  " or higher";
             }
             msg += ".";
+            throw new MojoFailureException(msg);
+        }
+
+        if(failOnCount > 0 && vulns.size() >= failOnCount) {
+            String msg = "Found vulnerabilities " + vulns.size() + ", which is more than the allowed " + failOnCount + ".";
             throw new MojoFailureException(msg);
         }
     }


### PR DESCRIPTION

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk-maven-plugin/blob/master/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

 #### What does this PR do?
Add small optional to fail the build based on vulnerability count instead of severity. 

 #### Where should the reviewer start?
PR should be straightforward. I'm unsure about what to do with the version in the pom.xml, but bumped it just in case. 

 #### How should this be manually tested?
Configure plugin like this and run against vulnerable project: 

                <configuration>
                    <failOnSeverity>false</failOnSeverity>
                    <failOnCount>5</failOnCount>
                </configuration>

 #### Any background context you want to provide?
Most of our projects does not have the option to fail on a just single severity (low, medium, higher), as the framework we use usually has 2-3 known vulnerabilities even though it has a weekly release cycle. In essence this means that we won't use the snyk maven plugin for testing. For us right now, it makes more sense to be able to fail the build if we have a larger set vulnerabilities e.g. 5 or higher. 

 #### What are the relevant tickets?
None

 #### Screenshots
None

 #### Additional questions
None