### PR TITLE
feat: New optional parameter, fail build if authentication fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The Snyk Maven plugin tests and monitors your Maven dependencies.
         <plugin>
             <groupId>io.snyk</groupId>
             <artifactId>snyk-maven-plugin</artifactId>
-            <version>1.2.5</version>
+            <version>1.2.6-SNAPSHOT</version>
             <executions>
                 <execution>
                     <id>snyk-test</id>
@@ -60,6 +60,7 @@ This plugin is supported by Maven version 3.1.0 and above.
 The following are elements in the `<configuration></configuration>` section of the plugin:
 
 - **apiToken** (mandatory): The **apiToken** is used to authenticate with the Snyk services. With the API token, the plugin can be configured with it as a system property or environment variable. The token can also be manually added to the pom.xml, although this is not the recommended method. This is mandatory configuration.
+- **failOnAuthError** (optional): Setting **failOnAuthError** to true will fail the build if authentication fails. Default value is `false`
 - **failOnSeverity** (optional): Setting **failOnSeverity** to any of the values (`low`, `medium` or `high`) will fail the Maven build if a severity is found at or above what was configured. This configuration is optional, and will be set to `low` if not defined. Setting it to `false` will never fail the build.
 - **org** (optional): The **org** configuration element sets under which of your Snyk organisations the project will be recorded. Leaving out this configuration will record the project under your default organisation.
 - **includeProvidedDependencies** (optional): The **includeProvidedDependencies** configuration element allows to include dependencies with `provided` scope. Default value is `true`.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>io.snyk</groupId>
   <artifactId>snyk-maven-plugin</artifactId>
-  <version>1.2.5</version>
+  <version>1.2.6-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>Snyk.io Maven Plugin</name>

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -8,7 +8,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <snyk.maven.plugin.version>1.2.5</snyk.maven.plugin.version>
+                <snyk.maven.plugin.version>1.2.6-SNAPSHOT</snyk.maven.plugin.version>
             </properties>
             <repositories>
                 <repository>

--- a/src/main/java/io/snyk/maven/plugins/Constants.java
+++ b/src/main/java/io/snyk/maven/plugins/Constants.java
@@ -2,6 +2,8 @@ package io.snyk.maven.plugins;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+
+import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
 
 /**
@@ -9,6 +11,14 @@ import org.apache.maven.plugin.logging.Log;
  * Created by dror on 05/05/2017.
  */
 public class Constants {
+
+    private static final String ERROR_UNAUTHORIZED_MORE_INFO = "See https://snyk.io/docs/using-snyk#authentication " +
+            "for more information.";
+
+    private static final String ERROR_UNAUTHORIZED_ENSURE_API_TOKEN = "Please ensure you have provided your Snyk's API token " +
+            "in the <apiToken></apiToken> plugin configuration option.";
+
+    private static final String ERROR_UNAUTHORIZED_SNYK_PLUGIN = "Unauthorized Snyk plugin.";
 
     public static final String SNYK_FILENAME = ".snyk";
 
@@ -42,12 +52,14 @@ public class Constants {
      * display a generic authentication error message to the build log
      * @param log the build log
      */
-    public static void displayAuthError(Log log) {
-        log.error("Unauthorized Snyk plugin.");
-        log.error("Please ensure you have provided your Snyk's API token " +
-                "in the <apiToken></apiToken> plugin configuration option.");
-        log.error("See https://snyk.io/docs/using-snyk#authentication " +
-                "for more information.");
+    public static void displayAuthError(Log log, boolean failOnAuthError) throws MojoFailureException {
+        if (failOnAuthError) {
+            throw new MojoFailureException(
+                    String.join(" ", ERROR_UNAUTHORIZED_SNYK_PLUGIN, ERROR_UNAUTHORIZED_ENSURE_API_TOKEN, ERROR_UNAUTHORIZED_MORE_INFO));
+        }
+        log.error(ERROR_UNAUTHORIZED_SNYK_PLUGIN);
+        log.error(ERROR_UNAUTHORIZED_ENSURE_API_TOKEN);
+        log.error(ERROR_UNAUTHORIZED_MORE_INFO);
     }
 
 }

--- a/src/main/java/io/snyk/maven/plugins/SnykTest.java
+++ b/src/main/java/io/snyk/maven/plugins/SnykTest.java
@@ -76,6 +76,9 @@ public class SnykTest extends AbstractMojo {
     @Parameter
     private boolean includeProvidedDependencies = true;
 
+    @Parameter
+    private boolean failOnAuthError = false;
+
     private String baseUrl = "";
 
     private static int SEVERITY_LOW     = 100;
@@ -137,10 +140,10 @@ public class SnykTest extends AbstractMojo {
      * validate the plugin's parameters
      * @return false if validation didn't pass
      */
-    private boolean validateParameters() {
+    private boolean validateParameters() throws MojoFailureException {
         boolean validated = true;
         if(apiToken.isEmpty()) {
-            Constants.displayAuthError(getLog());
+            Constants.displayAuthError(getLog(), failOnAuthError);
             validated = false;
         }
         baseUrl = Constants.parseEndpoint(endpoint);
@@ -206,10 +209,10 @@ public class SnykTest extends AbstractMojo {
      * and log it in the build log
      * @param response an HTTP response object
      */
-    private void processError(HttpResponse response) {
+    private void processError(HttpResponse response) throws MojoFailureException {
         // process an error in the response object
         if(response.getStatusLine().toString().contains("401")) {
-            Constants.displayAuthError(getLog());
+            Constants.displayAuthError(getLog(), failOnAuthError);
         } else {
             getLog().error("Bad response from Snyk: " +
                 response.getStatusLine().toString());


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk-maven-plugin/blob/master/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

 #### What does this PR do?
Adds a configuration parameter to fail the build if authentication fails, instead of just logging errors.

 #### Where should the reviewer start?
PR should be straightforward

 #### How should this be manually tested?
Configure the plugin with failOnAuthError=true and run a build without setting the apiToken. The build should now fail.

 #### Any background context you want to provide?
Created this based on some discussions on our internal shared signicat-snyk slack channel. 
Ref: Eliran Cohen
Our ref: PLAT-164

 #### What are the relevant tickets?
N/A

 #### Screenshots
N/A

 #### Additional questions
The tests `-Prun-its` was failing before I started, and I did not spend time on why. 