### PR TITLE
feat: log response on debug level when request failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The Snyk Maven plugin tests and monitors your Maven dependencies.
         <plugin>
             <groupId>io.snyk</groupId>
             <artifactId>snyk-maven-plugin</artifactId>
-            <version>1.2.6</version>
+            <version>1.2.7</version>
             <executions>
                 <execution>
                     <id>snyk-test</id>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>io.snyk</groupId>
   <artifactId>snyk-maven-plugin</artifactId>
-  <version>1.2.6</version>
+  <version>1.2.7</version>
   <packaging>maven-plugin</packaging>
 
   <name>Snyk.io Maven Plugin</name>

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -8,7 +8,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <snyk.maven.plugin.version>1.2.6</snyk.maven.plugin.version>
+                <snyk.maven.plugin.version>1.2.7</snyk.maven.plugin.version>
             </properties>
             <repositories>
                 <repository>

--- a/src/main/java/io/snyk/maven/plugins/SnykMonitor.java
+++ b/src/main/java/io/snyk/maven/plugins/SnykMonitor.java
@@ -254,6 +254,22 @@ public class SnykMonitor extends AbstractMojo {
         } else {
             getLog().error("Bad response from Snyk: " +
                 response.getStatusLine().toString());
+            if (getLog().isDebugEnabled()) {
+                getLog().debug("Snyk http response: " + parseResponseBody(response));
+            }
+        }
+    }
+
+    private JSONObject parseResponseBody(HttpResponse response) {
+        JSONParser parser = new JSONParser();
+        try {
+            JSONObject jsonObject = (JSONObject)parser.parse(
+                new BufferedReader(
+                    new InputStreamReader(
+                        response.getEntity().getContent())));
+            return jsonObject;
+        } catch (IOException|ParseException e) {
+            return null;
         }
     }
 }

--- a/src/main/java/io/snyk/maven/plugins/SnykTest.java
+++ b/src/main/java/io/snyk/maven/plugins/SnykTest.java
@@ -216,6 +216,9 @@ public class SnykTest extends AbstractMojo {
         } else {
             getLog().error("Bad response from Snyk: " +
                 response.getStatusLine().toString());
+            if (getLog().isDebugEnabled()) {
+                getLog().debug("Snyk http response: " + parseResponseBody(response));
+            }
         }
     }
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk-maven-plugin/blob/master/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

 #### What does this PR do?
This PR logs response on debug level if snyk test or monitor failed.
