### PR TITLE
chore: bump plugin version to 1.2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The Snyk Maven plugin tests and monitors your Maven dependencies.
         <plugin>
             <groupId>io.snyk</groupId>
             <artifactId>snyk-maven-plugin</artifactId>
-            <version>1.2.7</version>
+            <version>1.2.9</version>
             <executions>
                 <execution>
                     <id>snyk-test</id>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>io.snyk</groupId>
   <artifactId>snyk-maven-plugin</artifactId>
-  <version>1.2.9-SNAPSHOT</version>
+  <version>1.2.9</version>
   <packaging>maven-plugin</packaging>
 
   <name>Snyk.io Maven Plugin</name>

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -8,7 +8,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <snyk.maven.plugin.version>1.2.9-SNAPSHOT</snyk.maven.plugin.version>
+                <snyk.maven.plugin.version>1.2.9</snyk.maven.plugin.version>
             </properties>
             <repositories>
                 <repository>


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk-maven-plugin/blob/master/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

 #### What does this PR do?
This PR bumps plugin version to `1.2.9`, before releasing to Maven Central.
