### PR TITLE
Option to allow project version to be appended to the project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The following are elements in the `<configuration></configuration>` section of t
 - **org** (optional): The **org** configuration element sets under which of your Snyk organisations the project will be recorded. Leaving out this configuration will record the project under your default organisation.
 - **includeProvidedDependencies** (optional): The **includeProvidedDependencies** configuration element allows to include dependencies with `provided` scope. Default value is `true`.
 - **skip** (optional): The **skip** configuration element allows to skip plugin's execution when setting it to `true`. Default value is `false`.
+- **longFormProjectName** (optional): The **longFormProjectName** configuration element appends project version to the project name when is set to `true`. Default value is `false`.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The Snyk Maven plugin tests and monitors your Maven dependencies.
         <plugin>
             <groupId>io.snyk</groupId>
             <artifactId>snyk-maven-plugin</artifactId>
-            <version>1.2.9</version>
+            <version>1.2.10-SNAPSHOT</version>
             <executions>
                 <execution>
                     <id>snyk-test</id>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>io.snyk</groupId>
   <artifactId>snyk-maven-plugin</artifactId>
-  <version>1.2.9</version>
+  <version>1.2.10-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>Snyk.io Maven Plugin</name>

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -8,7 +8,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <snyk.maven.plugin.version>1.2.9</snyk.maven.plugin.version>
+                <snyk.maven.plugin.version>1.2.10-SNAPSHOT</snyk.maven.plugin.version>
             </properties>
             <repositories>
                 <repository>

--- a/src/main/java/io/snyk/maven/plugins/SnykMonitor.java
+++ b/src/main/java/io/snyk/maven/plugins/SnykMonitor.java
@@ -79,6 +79,9 @@ public class SnykMonitor extends AbstractMojo {
     @Parameter(property = "snyk.skip")
     private boolean skip;
 
+    @Parameter(property = "snyk.longFormProjectName")
+    private boolean longFormProjectName;
+
     private String baseUrl = "";
 
     /**
@@ -175,6 +178,10 @@ public class SnykMonitor extends AbstractMojo {
      */
     private JSONObject prepareRequestBody(JSONObject projectTree) {
         JSONObject body = new JSONObject();
+
+        if (longFormProjectName) {
+            projectTree.replace("name", projectTree.get("name") + ":" + projectTree.get("version"));
+        }
 
         JSONObject meta = new JSONObject();
         String groupId = project.getGroupId();

--- a/src/main/java/io/snyk/maven/plugins/SnykTest.java
+++ b/src/main/java/io/snyk/maven/plugins/SnykTest.java
@@ -82,6 +82,9 @@ public class SnykTest extends AbstractMojo {
     @Parameter(property = "snyk.skip")
     private boolean skip;
 
+    @Parameter(property = "snyk.longFormProjectName")
+    private boolean longFormProjectName;
+
     private String baseUrl = "";
 
     private static int SEVERITY_LOW     = 100;
@@ -139,6 +142,10 @@ public class SnykTest extends AbstractMojo {
 
         JSONObject projectTree = new ProjectTraversal(
                 project, repoSystem, repoSession, remoteRepositories, includeProvidedDependencies).getTree();
+
+        if (longFormProjectName) {
+            projectTree.replace("name", projectTree.get("name") + ":" + projectTree.get("version"));
+        }
 
         HttpResponse response = sendDataToSnyk(projectTree);
         parseResponse(response);


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk-maven-plugin/blob/master/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

Closes #91

 #### What does this PR do?

Sets both configuration and CLI option to allow project version to be appended to the project name.

 #### Where should the reviewer start?

Simple changes in SnykMonitor and SnykTest to add the functionality

 #### How should this be manually tested?

Executing the plugin with the <longFormProjectName> configuration parameter on the project's pom or
using the CLI option -Dsnyk.longFormProjectName

 #### Any background context you want to provide?

N/A

 #### What are the relevant tickets?

N/A

 #### Screenshots

N/A

 #### Additional questions

N/A