### PR TITLE
chore: remove annotation missing from deps

### DIFF
--- a/src/main/java/io/snyk/snyk_maven_plugin/download/Platform.java
+++ b/src/main/java/io/snyk/snyk_maven_plugin/download/Platform.java
@@ -1,7 +1,5 @@
 package io.snyk.snyk_maven_plugin.download;
 
-import com.google.common.annotations.VisibleForTesting;
-
 import java.nio.file.Paths;
 import java.util.Locale;
 
@@ -21,8 +19,7 @@ public enum Platform {
         return detect(System.getProperty("os.name"));
     }
 
-    @VisibleForTesting
-    public static Platform detect(String osName) {
+    protected static Platform detect(String osName) {
         String osNameLower = osName.toLowerCase(Locale.ENGLISH);
         if (osNameLower.contains("linux")) {
             return Paths.get("/etc/alpine-release").toFile().exists() ? LINUX_ALPINE : LINUX;


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk-maven-plugin/blob/master/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

 #### What does this PR do?

Removes VisibleForTesting annotations as it's not in dependencies and causes build issues on clean Maven installations. It works sometimes because some other project adds it to `.m2`. I don't think we need an entire dependency for this yet so I removed it entirely.
