### PR TITLE
refactor: avoid leaking Maven details beyond MOJO

### DIFF
--- a/src/main/java/io/snyk/snyk_maven_plugin/command/CommandRunner.java
+++ b/src/main/java/io/snyk/snyk_maven_plugin/command/CommandRunner.java
@@ -1,9 +1,5 @@
 package io.snyk.snyk_maven_plugin.command;
 
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugin.logging.Log;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -11,19 +7,15 @@ import java.io.InputStreamReader;
 
 public class CommandRunner {
 
-    public static void run(CommandLine commandLine, Log log) throws MojoFailureException, MojoExecutionException {
+    public static int run(CommandLine commandLine, LineLogger infoLogger, LineLogger errorLogger) {
         try {
             Process process = commandLine.start();
-            logStream(process.getInputStream(), log::info); // process stdout goes to plugin input
-            logStream(process.getErrorStream(), log::error);
+            logStream(process.getInputStream(), infoLogger); // process stdout goes to plugin input
+            logStream(process.getErrorStream(), errorLogger);
             process.waitFor();
-
-            int exitStatus = process.exitValue();
-            if (exitStatus != 0) {
-                throw new MojoFailureException("command existed with non-zero exit code (" + exitStatus + ")");
-            }
+            return process.exitValue();
         } catch (IOException | InterruptedException e) {
-            throw new MojoExecutionException("command execution failed", e);
+            throw new RuntimeException("command execution failed", e);
         }
     }
 

--- a/src/main/java/io/snyk/snyk_maven_plugin/download/CLIVersions.java
+++ b/src/main/java/io/snyk/snyk_maven_plugin/download/CLIVersions.java
@@ -1,7 +1,5 @@
 package io.snyk.snyk_maven_plugin.download;
 
-import org.apache.maven.plugin.MojoExecutionException;
-
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -16,9 +14,9 @@ public class CLIVersions {
         return versionMatcher.matches();
     }
 
-    public static String sanitize(String version) throws MojoExecutionException {
+    public static String sanitize(String version) {
         if (!isValidCLIVersion(version)) {
-            throw new MojoExecutionException("Invalid Snyk CLI version. It should be a valid semver e.g. 1.489.0");
+            throw new IllegalArgumentException("Invalid Snyk CLI version. It should be a valid semver e.g. 1.489.0");
         }
 
         // Add "v" prefix e.g. v1.456.0 if needed

--- a/src/main/java/io/snyk/snyk_maven_plugin/download/ExecutableDownloader.java
+++ b/src/main/java/io/snyk/snyk_maven_plugin/download/ExecutableDownloader.java
@@ -1,7 +1,5 @@
 package io.snyk.snyk_maven_plugin.download;
 
-import org.apache.maven.plugin.MojoExecutionException;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -15,19 +13,23 @@ import static java.lang.String.format;
 public class ExecutableDownloader {
     private static final String SNYK_RELEASES_LATEST = "https://static.snyk.io/cli/%s/%s";
 
-    public static File download(Path destination, Platform platform, String version) throws IOException, MojoExecutionException {
-        String sanitizedVersion = CLIVersions.sanitize(version);
-
-        URL url = new URL(format(SNYK_RELEASES_LATEST, sanitizedVersion, platform.snykExecutableFileName));
-        destination.toFile().mkdirs();
-        File file = destination.resolve(platform.snykExecutableFileName).toFile();
-        try (
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    public static File download(Path destination, Platform platform, String version) {
+        try {
+            String sanitizedVersion = CLIVersions.sanitize(version);
+            URL url = new URL(format(SNYK_RELEASES_LATEST, sanitizedVersion, platform.snykExecutableFileName));
+            destination.toFile().mkdirs();
+            File file = destination.resolve(platform.snykExecutableFileName).toFile();
+            try (
                 ReadableByteChannel rbc = Channels.newChannel(url.openStream());
                 FileOutputStream fos = new FileOutputStream(file);
-        ) {
-            fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
+            ) {
+                fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
+            }
+            file.setExecutable(true);
+            return file;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
-        file.setExecutable(true);
-        return file;
     }
 }

--- a/src/test/java/io/snyk/snyk_maven_plugin/download/CLIVersionsTest.java
+++ b/src/test/java/io/snyk/snyk_maven_plugin/download/CLIVersionsTest.java
@@ -1,6 +1,5 @@
 package io.snyk.snyk_maven_plugin.download;
 
-import org.apache.maven.plugin.MojoExecutionException;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -9,20 +8,20 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class CLIVersionsTest {
 
     @Test
-    public void acceptsLatest() throws MojoExecutionException {
+    public void acceptsLatest() {
         assertEquals("latest", CLIVersions.sanitize("latest"));
         assertEquals(CLIVersions.LATEST_VERSION_KEYWORD, CLIVersions.sanitize(CLIVersions.LATEST_VERSION_KEYWORD));
     }
 
     @Test
-    public void acceptsVersion() throws MojoExecutionException {
+    public void acceptsVersion() {
         assertEquals("v1.456.3", CLIVersions.sanitize("1.456.3"));
     }
 
     @Test
     public void throwsOnInvalidVersions() {
-        assertThrows(MojoExecutionException.class, () -> CLIVersions.sanitize("dev"));
-        assertThrows(MojoExecutionException.class, () -> CLIVersions.sanitize("1.13"));
-        assertThrows(MojoExecutionException.class, () -> CLIVersions.sanitize("1.13.0-alpha"));
+        assertThrows(IllegalArgumentException.class, () -> CLIVersions.sanitize("dev"));
+        assertThrows(IllegalArgumentException.class, () -> CLIVersions.sanitize("1.13"));
+        assertThrows(IllegalArgumentException.class, () -> CLIVersions.sanitize("1.13.0-alpha"));
     }
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk-maven-plugin/blob/master/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

 #### What does this PR do?
It's difficult to know where the behaviour to satisfy Maven lies so I've moved all exception handling up to the `execute` where it decides what's a MojoExecution and MojoFailure exception. No other class should be aware of Maven.

I've also reduced checked exception propagation noise using unchecked exceptions.