### PR TITLE
Set minimum maven version prerequisite

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <url>https://snyk.io</url>
 
   <prerequisites>
-    <maven>${maven.version}</maven>
+    <maven>3.1.0</maven>
   </prerequisites>
 
   <properties>


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk-maven-plugin/blob/master/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

 #### What does this PR do?
Sets the plugin pre-requisite minimum to Maven 3.1.0

 #### Any background context you want to provide?
Test project was failing to run from command line because of this.
