### PR TITLE
feat: forward color output support to command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,11 @@
       <version>3.6.0</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-shared-utils</artifactId>
+      <version>3.3.3</version>
+    </dependency>
 
     <!-- Jodd -->
     <dependency>

--- a/src/main/java/io/snyk/snyk_maven_plugin/AbstractSnykMojo.java
+++ b/src/main/java/io/snyk/snyk_maven_plugin/AbstractSnykMojo.java
@@ -12,6 +12,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.shared.utils.logging.MessageUtils;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -43,7 +44,8 @@ public abstract class AbstractSnykMojo extends AbstractMojo {
                 getExecutable().getAbsolutePath(),
                 getCommand(),
                 Optional.ofNullable(apiToken),
-                args
+                args,
+                MessageUtils.isColorEnabled()
             );
             Log log = getLog();
             return CommandRunner.run(commandLine::start, log::info, log::error);

--- a/src/main/java/io/snyk/snyk_maven_plugin/command/CommandLine.java
+++ b/src/main/java/io/snyk/snyk_maven_plugin/command/CommandLine.java
@@ -13,13 +13,18 @@ public interface CommandLine {
         String cliExecutablePath,
         Command command,
         Optional<String> apiToken,
-        List<String> args
+        List<String> args,
+        boolean color
     ) {
         ProcessBuilder pb = new ProcessBuilder(new ArrayList<String>() {{
             add(cliExecutablePath);
             add(command.commandName());
             addAll(args);
         }});
+
+        if (color) {
+            pb.environment().put("FORCE_COLOR", "true");
+        }
 
         apiToken.ifPresent((t) -> {
             pb.environment().put("SNYK_TOKEN", t);

--- a/src/test/java/io/snyk/snyk_maven_plugin/command/CommandLineTest.java
+++ b/src/test/java/io/snyk/snyk_maven_plugin/command/CommandLineTest.java
@@ -10,15 +10,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CommandLineTest {
 
-    public static final String SNYK_TOKEN_FROM_POM_XML = "snyk-token-from-pom-xml";
-
     @Test
     public void shouldIncludePathAndCommandName() {
         ProcessBuilder pb = CommandLine.asProcessBuilder(
             "/path/to/cli",
             Command.TEST,
             Optional.empty(),
-            emptyList()
+            emptyList(),
+            false
         );
 
         assertEquals(
@@ -40,7 +39,8 @@ public class CommandLineTest {
                 "--print-deps",
                 "--all-projects",
                 "--json-file-output=out.json"
-            )
+            ),
+            false
         );
 
         assertEquals(
@@ -56,12 +56,28 @@ public class CommandLineTest {
     }
 
     @Test
+    public void shouldNotModifyEnvironmentByDefault() {
+        ProcessBuilder pb = CommandLine.asProcessBuilder(
+            "/path/to/cli",
+            Command.TEST,
+            Optional.empty(),
+            emptyList(),
+            false
+        );
+        assertEquals(
+            System.getenv(),
+            pb.environment()
+        );
+    }
+
+    @Test
     public void shouldIncludeAPIToken() {
         ProcessBuilder pb = CommandLine.asProcessBuilder(
             "/path/to/cli",
             Command.TEST,
             Optional.of("fake-token"),
-            emptyList()
+            emptyList(),
+            false
         );
 
         assertEquals(
@@ -71,16 +87,18 @@ public class CommandLineTest {
     }
 
     @Test
-    public void shouldNotIncludeAPITokenWhenNotGiven() {
+    public void shouldForceColorWhenEnabled() {
         ProcessBuilder pb = CommandLine.asProcessBuilder(
             "/path/to/cli",
             Command.TEST,
             Optional.empty(),
-            emptyList()
+            emptyList(),
+            true
         );
         assertEquals(
-            SNYK_TOKEN_FROM_POM_XML,
-            pb.environment().get("SNYK_TOKEN")
+            "true",
+            pb.environment().get("FORCE_COLOR")
         );
     }
+
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk-maven-plugin/blob/master/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

 #### What does this PR do?
ProcessBuilder executes in a non-TTY environment so chalk disables colour by default. This PR detects if the current plugin runtime (Maven) supports colour and forwards that preference to the command process using `FORCE_COLOR` which is supported by `chalk`. Since we forward all output back to Maven, we don't care if ProcessBuilder is a TTY or not.

Using `mvn -B test` will force no colour. Otherwise colour is generally supported.