### PR TITLE
feat: support skip flag in pom and properties

### DIFF
--- a/src/it/test-skip-pom/invoker.properties
+++ b/src/it/test-skip-pom/invoker.properties
@@ -1,0 +1,3 @@
+# https://maven.apache.org/plugins/maven-invoker-plugin/integration-test-mojo.html#invokerPropertiesFile
+invoker.goals = test
+invoker.buildResult = success

--- a/src/it/test-skip-pom/pom.xml
+++ b/src/it/test-skip-pom/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.snyk.it</groupId>
+  <artifactId>test-skip-pom</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>axis</groupId>
+      <artifactId>axis</artifactId>
+      <version>1.4</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <skip>true</skip>
+          <cli>
+            <executable>${env.SNYK_CLI_EXECUTABLE}</executable>
+          </cli>
+          <apiToken>${env.SNYK_TEST_TOKEN}</apiToken>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/test-skip-pom/verify.groovy
+++ b/src/it/test-skip-pom/verify.groovy
@@ -1,0 +1,9 @@
+import org.codehaus.plexus.util.FileUtils;
+
+String log = FileUtils.fileRead(new File(basedir, "build.log"));
+
+if (!log.contains("snyk test skipped")) {
+    throw new Exception("skip message not found");
+}
+
+return true;

--- a/src/it/test-skip-property/invoker.properties
+++ b/src/it/test-skip-property/invoker.properties
@@ -1,0 +1,3 @@
+# https://maven.apache.org/plugins/maven-invoker-plugin/integration-test-mojo.html#invokerPropertiesFile
+invoker.goals = test -Dsnyk.skip
+invoker.buildResult = success

--- a/src/it/test-skip-property/pom.xml
+++ b/src/it/test-skip-property/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.snyk.it</groupId>
+  <artifactId>test-skip-property</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>axis</groupId>
+      <artifactId>axis</artifactId>
+      <version>1.4</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <cli>
+            <executable>${env.SNYK_CLI_EXECUTABLE}</executable>
+          </cli>
+          <apiToken>${env.SNYK_TEST_TOKEN}</apiToken>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/test-skip-property/verify.groovy
+++ b/src/it/test-skip-property/verify.groovy
@@ -1,0 +1,9 @@
+import org.codehaus.plexus.util.FileUtils;
+
+String log = FileUtils.fileRead(new File(basedir, "build.log"));
+
+if (!log.contains("snyk test skipped")) {
+    throw new Exception("skip message not found");
+}
+
+return true;

--- a/src/main/java/io/snyk/snyk_maven_plugin/AbstractSnykMojo.java
+++ b/src/main/java/io/snyk/snyk_maven_plugin/AbstractSnykMojo.java
@@ -33,7 +33,15 @@ public abstract class AbstractSnykMojo extends AbstractMojo {
     @Parameter
     protected List<String> args;
 
+    @Parameter(property = "snyk.skip")
+    protected boolean skip;
+
     public void execute() throws MojoFailureException, MojoExecutionException {
+        if (skip) {
+            getLog().info("snyk " + getCommand().commandName() + " skipped");
+            return;
+        }
+
         int exitCode = executeCommand();
         if (exitCode != 0) {
             throw new MojoFailureException("snyk command exited with non-zero exit code (" + exitCode + "). See output for details.");


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk-maven-plugin/blob/master/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

 #### What does this PR do?

Adds a `skip` flag to pom configuration and `-Dsnyk.skip` support like the previous plugin (similar to Invoker plugins `invoker.skip`).

The Surefire plugin has a more global `-DskipTests` but not all plugins use this (like Invoker), [some do](http://maven.apache.org/plugins-archives/maven-surefire-plugin-2.12.4/examples/skipping-test.html). So I don't think we should either. Better to be explicitly skipped.

For testing, it's difficult to assert the command isn't executed as the CLI output can change and pass the test incorrectly. Maybe we can have a mock API endpoint which we can assert on to not have received requests. But this might require moving off the limited `verify.groovy` scripts.