### PR TITLE
chore: run acceptance tests in parallel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,7 @@
           <environmentVariables>
             <SNYK_TOKEN><!-- disable global environment auth for tests --></SNYK_TOKEN>
           </environmentVariables>
+          <parallelThreads>0.5C</parallelThreads>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk-maven-plugin/blob/master/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

 #### What does this PR do?

Runs acceptance tests in parallel. In this case, if you have 16 cores, it'll run 8 tests at a time (`0.5 x C`). This cuts down test times from 1 minute to 30 seconds (on my laptop) so we can save on dev time. I used 0.5 to avoid over stressing the CPU which may be needed for other tasks. We'll see how GitHub Actions behaves with this PR.

The risk is introducing flakey tests but I don't think we have that problem. Only one test tests for auto-download (global state), the other global state is `.m2` which Maven can handle. In general we should avoid global state anyway so it's good to get this in early to detect issues.