### PR TITLE
feat: always include integration-name

### DIFF
--- a/src/main/java/io/snyk/snyk_maven_plugin/command/CommandLine.java
+++ b/src/main/java/io/snyk/snyk_maven_plugin/command/CommandLine.java
@@ -1,11 +1,14 @@
 package io.snyk.snyk_maven_plugin.command;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public interface CommandLine {
+
+    String INTEGRATION_NAME = "MAVEN_PLUGIN";
 
     Process start() throws IOException;
 
@@ -16,11 +19,20 @@ public interface CommandLine {
         List<String> args,
         boolean color
     ) {
-        ProcessBuilder pb = new ProcessBuilder(new ArrayList<String>() {{
-            add(cliExecutablePath);
-            add(command.commandName());
-            addAll(args);
-        }});
+        Stream<String> baseParts = Stream.of(
+            cliExecutablePath,
+            command.commandName(),
+            "--integration-name=" + INTEGRATION_NAME
+        );
+
+        Stream<String> normalisedArgs = args.stream()
+            .map(String::trim)
+            .filter(arg -> !arg.startsWith("--integration-name"));
+
+        List<String> parts = Stream.concat(baseParts, normalisedArgs)
+            .collect(Collectors.toList());
+
+        ProcessBuilder pb = new ProcessBuilder(parts);
 
         if (color) {
             pb.environment().put("FORCE_COLOR", "true");

--- a/src/test/java/io/snyk/snyk_maven_plugin/command/CommandLineTest.java
+++ b/src/test/java/io/snyk/snyk_maven_plugin/command/CommandLineTest.java
@@ -4,14 +4,16 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
+import static io.snyk.snyk_maven_plugin.command.CommandLine.INTEGRATION_NAME;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CommandLineTest {
 
     @Test
-    public void shouldIncludePathAndCommandName() {
+    public void shouldIncludePathCommandNameIntegrationName() {
         ProcessBuilder pb = CommandLine.asProcessBuilder(
             "/path/to/cli",
             Command.TEST,
@@ -23,22 +25,23 @@ public class CommandLineTest {
         assertEquals(
             asList(
                 "/path/to/cli",
-                "test"
+                "test",
+                "--integration-name=" + INTEGRATION_NAME
             ),
             pb.command()
         );
     }
 
     @Test
-    public void shouldIncludeArguments() {
+    public void shouldIncludeTrimmedArguments() {
         ProcessBuilder pb = CommandLine.asProcessBuilder(
             "/path/to/cli",
             Command.TEST,
             Optional.empty(),
             asList(
                 "--print-deps",
-                "--all-projects",
-                "--json-file-output=out.json"
+                "  --all-projects  ",
+                "--json-file-output=out.json  "
             ),
             false
         );
@@ -47,9 +50,30 @@ public class CommandLineTest {
             asList(
                 "/path/to/cli",
                 "test",
+                "--integration-name=" + INTEGRATION_NAME,
                 "--print-deps",
                 "--all-projects",
                 "--json-file-output=out.json"
+            ),
+            pb.command()
+        );
+    }
+
+    @Test
+    public void shouldNotChangeIntegrationName() {
+        ProcessBuilder pb = CommandLine.asProcessBuilder(
+            "/path/to/cli",
+            Command.TEST,
+            Optional.empty(),
+            singletonList("--integration-name=this-is-not-ok"),
+            false
+        );
+
+        assertEquals(
+            asList(
+                "/path/to/cli",
+                "test",
+                "--integration-name=" + INTEGRATION_NAME
             ),
             pb.command()
         );


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk-maven-plugin/blob/master/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

 #### What does this PR do?
We need the integration-name to separate executions via this plugin from direct CLI executions. Also, if an `--integration-name` arg is detected, it will be ignored. Though, I'm not 100% sure if we should fail or allow it so that's up for discussion.

I also added a step to normalise the args a bit by trimming whitespace to make detecting `--integration-name` easier.