### PR TITLE
chore: cache local maven repository in ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,16 @@ jobs:
         with:
           java-version: 8
 
-      - name: Install Plugin to .m2
+      - name: Cache Local Maven Repository
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.m2/wrapper
+          key: ${{ runner.os }}-maven-${{ hashFiles('pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+
+      - name: Install Plugin to Local Maven Repository
         run: mvn -B install "-DskipTests" "-Dinvoker.skip=true"
 
       - name: Run Unit Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,44 +7,44 @@ jobs:
     strategy:
       fail-fast: false  # we care about other platforms and channels building
       matrix:
-        os: [ubuntu, macos, windows]
+        os: [ ubuntu, macos, windows ]
     runs-on: ${{ matrix.os }}-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 8
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
 
-    - name: Install Plugin to .m2
-      run: mvn -B install "-DskipTests" "-Dinvoker.skip=true"
-    
-    - name: Run Unit Tests
-      run: mvn -B surefire:test
-    
-    - name: Install Snyk CLI (Ubuntu/macOS)
-      if: ${{ matrix.os != 'windows' }}
-      run: sudo npm install -g snyk
+      - name: Install Plugin to .m2
+        run: mvn -B install "-DskipTests" "-Dinvoker.skip=true"
 
-    - name: Install Snyk CLI (Windows)
-      if: ${{ matrix.os == 'windows' }}
-      run: npm install -g snyk
+      - name: Run Unit Tests
+        run: mvn -B surefire:test
 
-    - name: Run Acceptance Tests (Ubuntu/macOS)
-      if: ${{ matrix.os != 'windows' }}
-      run: mvn -B invoker:install invoker:run
-      env:
-        SNYK_TEST_TOKEN: ${{secrets.SNYK_TEST_TOKEN}}
-        SNYK_CLI_EXECUTABLE: /usr/local/bin/snyk
+      - name: Install Snyk CLI (Ubuntu/macOS)
+        if: ${{ matrix.os != 'windows' }}
+        run: sudo npm install -g snyk
 
-    - name: Run Acceptance Tests (Windows)
-      if: ${{ matrix.os == 'windows' }}
-      run: mvn -B invoker:install invoker:run
-      env:
-        SNYK_TEST_TOKEN: ${{secrets.SNYK_TEST_TOKEN}}
-        SNYK_CLI_EXECUTABLE: "C:\\npm\\prefix\\snyk.cmd"
+      - name: Install Snyk CLI (Windows)
+        if: ${{ matrix.os == 'windows' }}
+        run: npm install -g snyk
 
-    - name: Show Integration Test build.log files
-      if: ${{ failure() }}
-      run: cat target/it/**/build.log
+      - name: Run Acceptance Tests (Ubuntu/macOS)
+        if: ${{ matrix.os != 'windows' }}
+        run: mvn -B invoker:install invoker:run
+        env:
+          SNYK_TEST_TOKEN: ${{secrets.SNYK_TEST_TOKEN}}
+          SNYK_CLI_EXECUTABLE: /usr/local/bin/snyk
+
+      - name: Run Acceptance Tests (Windows)
+        if: ${{ matrix.os == 'windows' }}
+        run: mvn -B invoker:install invoker:run
+        env:
+          SNYK_TEST_TOKEN: ${{secrets.SNYK_TEST_TOKEN}}
+          SNYK_CLI_EXECUTABLE: "C:\\npm\\prefix\\snyk.cmd"
+
+      - name: Show Integration Test build.log files
+        if: ${{ failure() }}
+        run: cat target/it/**/build.log


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk-maven-plugin/blob/master/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

 #### What does this PR do?

Currently we're downloading Maven deps on every test run in CI. That's wasteful so I've added a cache step.

Since we `mvn install` our plugin, this might cause false positives if say `mvn install` somehow fails without failing the build (unlikely without a bug in mvn) and the next steps use a previously cached plugin. Since it's unlikely I don't think it matters.

I also ran the YAML through Intellij as a separate commit for consistency. Might be easier to see the change by viewing the second commit.