### PR TITLE
feat: use recommended phases as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,39 +18,35 @@ Official [Snyk](https://snyk.io) Maven plugin tests and monitors your Maven depe
 
 ```xml
 <build>
-    <plugins>
-        <plugin>
-            <groupId>io.snyk</groupId>
-            <artifactId>snyk-maven-plugin</artifactId>
-            <version>2.0.0</version>
-            <executions>
-                <execution>
-                    <id>snyk-test</id>
-                    <phase>test</phase>
-                    <goals>
-                        <goal>test</goal>
-                    </goals>
-                </execution>
-                <execution>
-                    <id>snyk-monitor</id>
-                    <phase>install</phase>
-                    <goals>
-                        <goal>monitor</goal>
-                    </goals>
-                </execution>
-            </executions>
-            <configuration>
-                <apiToken>${env.SNYK_TOKEN}</apiToken>
-                <args>
-                    <arg>--all-projects</arg>
-                </args>
-            </configuration>
-        </plugin>
-    </plugins>
+  <plugins>
+    <plugin>
+      <groupId>io.snyk</groupId>
+      <artifactId>snyk-maven-plugin</artifactId>
+      <version>2.0.0</version>
+      <executions>
+        <execution>
+          <id>snyk-test</id>
+          <goals>
+            <goal>test</goal>
+          </goals>
+        </execution>
+        <execution>
+          <id>snyk-monitor</id>
+          <goals>
+            <goal>monitor</goal>
+          </goals>
+        </execution>
+      </executions>
+      <configuration>
+        <apiToken>${env.SNYK_TOKEN}</apiToken>
+        <args>
+          <arg>--all-projects</arg>
+        </args>
+      </configuration>
+    </plugin>
+  </plugins>
 </build>
 ```
-
-3. We recommend to set the **test** goal in the **test** phase of Maven; and the **monitor** goal in the **install** phase of Maven.
 
 ## Configuration
 

--- a/src/it/monitor-with-default-phase/invoker.properties
+++ b/src/it/monitor-with-default-phase/invoker.properties
@@ -1,0 +1,3 @@
+# https://maven.apache.org/plugins/maven-invoker-plugin/integration-test-mojo.html#invokerPropertiesFile
+invoker.goals = install
+invoker.buildResult = success

--- a/src/it/monitor-with-default-phase/pom.xml
+++ b/src/it/monitor-with-default-phase/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.snyk.it</groupId>
+  <artifactId>monitor-with-dependency</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>axis</groupId>
+      <artifactId>axis</artifactId>
+      <version>1.4</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>monitor</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <cli>
+            <executable>${env.SNYK_CLI_EXECUTABLE}</executable>
+          </cli>
+          <apiToken>${env.SNYK_TEST_TOKEN}</apiToken>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/monitor-with-default-phase/verify.groovy
+++ b/src/it/monitor-with-default-phase/verify.groovy
@@ -1,0 +1,9 @@
+import org.codehaus.plexus.util.FileUtils;
+
+String log = FileUtils.fileRead(new File(basedir, "build.log"));
+
+if (!log.contains("Explore this snapshot at")) {
+    throw new Exception("Snapshot link not found.");
+}
+
+return true;

--- a/src/it/test-with-default-phase/invoker.properties
+++ b/src/it/test-with-default-phase/invoker.properties
@@ -1,0 +1,3 @@
+# https://maven.apache.org/plugins/maven-invoker-plugin/integration-test-mojo.html#invokerPropertiesFile
+invoker.goals = test
+invoker.buildResult = success

--- a/src/it/test-with-default-phase/pom.xml
+++ b/src/it/test-with-default-phase/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.snyk.it</groupId>
+  <artifactId>test-without-dependency</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <cli>
+            <executable>${env.SNYK_CLI_EXECUTABLE}</executable>
+          </cli>
+          <apiToken>${env.SNYK_TEST_TOKEN}</apiToken>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/test-with-default-phase/verify.groovy
+++ b/src/it/test-with-default-phase/verify.groovy
@@ -1,0 +1,9 @@
+import org.codehaus.plexus.util.FileUtils;
+
+String log = FileUtils.fileRead(new File(basedir, "build.log"));
+
+if (!log.contains("for known issues, no vulnerable paths found.")) {
+    throw new Exception("`snyk test` success output not found");
+}
+
+return true;

--- a/src/main/java/io/snyk/snyk_maven_plugin/goal/SnykMonitorMojo.java
+++ b/src/main/java/io/snyk/snyk_maven_plugin/goal/SnykMonitorMojo.java
@@ -1,9 +1,10 @@
 package io.snyk.snyk_maven_plugin.goal;
 
 import io.snyk.snyk_maven_plugin.command.Command;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 
-@Mojo(name = "monitor")
+@Mojo(name = "monitor", defaultPhase = LifecyclePhase.INSTALL)
 public class SnykMonitorMojo extends SnykMojo {
 
     @Override

--- a/src/main/java/io/snyk/snyk_maven_plugin/goal/SnykTestMojo.java
+++ b/src/main/java/io/snyk/snyk_maven_plugin/goal/SnykTestMojo.java
@@ -1,9 +1,10 @@
 package io.snyk.snyk_maven_plugin.goal;
 
 import io.snyk.snyk_maven_plugin.command.Command;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 
-@Mojo(name = "test")
+@Mojo(name = "test", defaultPhase = LifecyclePhase.TEST)
 public class SnykTestMojo extends SnykMojo {
 
     @Override


### PR DESCRIPTION
 #### What does this PR do?

As we already recommend using `test` and `monitor` in specific phases, I've removed that setup step in favour of using sane defaults. Support for overriding  the default phase is standard Maven behaviour so we don't need to document it.