### PR TITLE
docs: use an available value for severity example

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ see [Snyk CLI Reference](https://support.snyk.io/hc/en-us/articles/360003812578-
 <!-- Example Arguments Configuration -->
 <configuration>
   <args>
-    <arg>--severity-threshold=critical</arg>
+    <arg>--severity-threshold=high</arg>
     <arg>--scan-all-unmanaged</arg>
     <arg>--json</arg>
   </args>


### PR DESCRIPTION
#### What does this PR do?

`critical` is not a valid value.