### PR TITLE
feat: ability to write Snyk CLI output to a specified output file

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ You must provide a Snyk API token to access Snyk's services. You can do so by:
 - Providing a `SNYK_TOKEN` environment variable.
 - Authenticating via `snyk auth` using the Snyk CLI before using this plugin.
 
+### `outputFile` \[string\]
+
+Default: `null`
+
+If present, the output from the Snyk CLI tool is written to this path as well
+as the console.  If the parent directory for the file does not exist, then it
+will be created.  The default behavior is to output only to the console.
+
 ### `skip` \[boolean\]
 
 Default: `false`

--- a/src/it/test-with-output-file/invoker.properties
+++ b/src/it/test-with-output-file/invoker.properties
@@ -1,0 +1,3 @@
+# https://maven.apache.org/plugins/maven-invoker-plugin/integration-test-mojo.html#invokerPropertiesFile
+invoker.goals = test
+invoker.buildResult = success

--- a/src/it/test-with-output-file/pom.xml
+++ b/src/it/test-with-output-file/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.snyk.it</groupId>
+  <artifactId>test-with-output-file</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <cli>
+            <executable>${env.SNYK_CLI_EXECUTABLE}</executable>
+          </cli>
+          <apiToken>${env.SNYK_TEST_TOKEN}</apiToken>
+          <outputFile>${project.build.directory}/snyk-test.txt</outputFile>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/test-with-output-file/verify.groovy
+++ b/src/it/test-with-output-file/verify.groovy
@@ -1,0 +1,15 @@
+import org.codehaus.plexus.util.FileUtils;
+
+String log = FileUtils.fileRead(new File(basedir, "build.log"))
+
+if (!log.contains("introduced by axis:axis@1.4")) {
+    throw new Exception("no vulnerable paths found")
+}
+
+String capturedOutput = FileUtils.fileRead(new File(new File(basedir, "target"), "snyk-test.txt"))
+
+if (!capturedOutput.contains("Package manager:   maven\nTarget file:       pom.xml")) {
+    throw new Exception("expected captured output not present");
+}
+
+return true

--- a/src/main/java/io/snyk/snyk_maven_plugin/command/CommandRunner.java
+++ b/src/main/java/io/snyk/snyk_maven_plugin/command/CommandRunner.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.Arrays;
 
 public class CommandRunner {
 
@@ -25,6 +26,20 @@ public class CommandRunner {
 
     public interface LineLogger {
         void log(String line);
+    }
+
+    public static class CompositeLineLogger implements LineLogger {
+
+        private final LineLogger[] delegates;
+
+        public CompositeLineLogger(LineLogger ...delegates) {
+            this.delegates = delegates;
+        }
+
+        @Override
+        public void log(String line) {
+            Arrays.stream(delegates).forEach(d -> d.log(line));
+        }
     }
 
 }

--- a/src/main/java/io/snyk/snyk_maven_plugin/goal/SnykMojo.java
+++ b/src/main/java/io/snyk/snyk_maven_plugin/goal/SnykMojo.java
@@ -30,6 +30,9 @@ public abstract class SnykMojo extends ComposedMojo {
     private boolean failOnIssues;
 
     @Parameter
+    private String outputFile;
+
+    @Parameter
     private CLI cli;
 
     public static class CLI {
@@ -60,6 +63,10 @@ public abstract class SnykMojo extends ComposedMojo {
 
     public boolean getFailOnIssues() {
         return failOnIssues;
+    }
+
+    public String getOutputFile() {
+        return outputFile;
     }
 
     public List<String> getArguments() {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk-maven-plugin/blob/master/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

 #### What does this PR do?

This PR will introduce a new option `outputFile` so that it is possible to capture the Snyk output into a flat file that can then be used in CI/CD pipeline workflows.  The command's output is also still copied to the regular Maven console output, but the "colour" is disabled in this case to prevent ANSI colour codes being sent to the file as well.

 #### Where should the reviewer start?

See the new commands in the `README.md` file and also see the changes in `SnykMojoExecutor.java`.

 #### How should this be manually tested?

From a project, where you have the Snyk Maven plugin installed and configured, add the following configuration line;

```
<outputFile>${project.build.directory}/snyk.txt</outputFile>
```

When you run the Snyk Maven plugin, the output should also be observed in `target/snyk.txt`.

 #### Any background context you want to provide?

The primary driver for this change is so that the Snyk CLI calls can be driven by the same logic in the local development environment as are made from the CI/CD pipeline; in both cases using Maven.  Without this change, the pipeline would have no means of collecting the output from the Maven-driven Snyk CLI because the text will be mixed with the other maven console log and so the pipeline has to run the commands again or disable them in Maven and run them separately.  The overall benefit is reduced complexity in the pipeline and consistency.

 #### What are the relevant tickets?

N/A

 #### Screenshots

N/A

 #### Additional questions

N/A