### PR TITLE
feat: add support for linux arm64

### DIFF
--- a/src/main/java/io/snyk/snyk_maven_plugin/download/ExecutableDestination.java
+++ b/src/main/java/io/snyk/snyk_maven_plugin/download/ExecutableDestination.java
@@ -30,6 +30,7 @@ public class ExecutableDestination {
                     .orElseThrow(() -> new MissingContextException("Windows needs APPDATA directory."));
             }
             case LINUX:
+            case LINUX_ARM64:
             case LINUX_ALPINE: {
                 return Optional.ofNullable(env.get("XDG_DATA_HOME"))
                     .map(Paths::get)

--- a/src/main/java/io/snyk/snyk_maven_plugin/download/Platform.java
+++ b/src/main/java/io/snyk/snyk_maven_plugin/download/Platform.java
@@ -5,6 +5,7 @@ import java.util.Locale;
 
 public enum Platform {
     LINUX("snyk-linux"),
+    LINUX_ARM64("snyk-linux-arm64"),
     LINUX_ALPINE("snyk-alpine"),
     MAC_OS("snyk-macos"),
     WINDOWS("snyk-win.exe");
@@ -16,18 +17,34 @@ public enum Platform {
     }
 
     public static Platform current() {
-        return detect(System.getProperty("os.name"));
+        return detect(System.getProperty("os.name"), System.getProperty("os.arch"));
     }
 
-    protected static Platform detect(String osName) {
+    protected static Platform detect(String osName, String arch) {
         String osNameLower = osName.toLowerCase(Locale.ENGLISH);
         if (osNameLower.contains("linux")) {
-            return Paths.get("/etc/alpine-release").toFile().exists() ? LINUX_ALPINE : LINUX;
+            if (Paths.get("/etc/alpine-release").toFile().exists()) {
+                switch (arch) {
+                    case "x86_64":
+                        return LINUX_ALPINE;
+                    default:
+                        throw new IllegalArgumentException("linux alpine " + arch + " is not supported.");
+                }
+            }
+            switch (arch) {
+                case "x86_64":
+                    return LINUX;
+                case "aarch64":
+                    return LINUX_ARM64;
+                default:
+                    throw new IllegalArgumentException("linux " + arch + " is not supported.");
+            }
         } else if (osNameLower.contains("mac os x") || osNameLower.contains("darwin") || osNameLower.contains("osx")) {
+            // Mac M1/M2 (Arm64) will happily run x86 under Rosetta2, no need to check arch
             return MAC_OS;
-        } else if (osNameLower.contains("windows")) {
+        } else if (osNameLower.contains("windows") && arch.equals("x86_64")) {
             return WINDOWS;
         }
-        throw new IllegalArgumentException(osNameLower + " is not supported.");
+        throw new IllegalArgumentException(osNameLower + "(" + arch + ") is not supported.");
     }
 }

--- a/src/test/java/io/snyk/snyk_maven_plugin/download/ExecutableDestinationTest.java
+++ b/src/test/java/io/snyk/snyk_maven_plugin/download/ExecutableDestinationTest.java
@@ -119,7 +119,31 @@ public class ExecutableDestinationTest {
     }
 
     @Test
-    public void alplineThrowsIfXgdNotSetAndHomeDirNotSet() {
+    public void worksLinuxArm64XgdSet() {
+        Platform platform = Platform.LINUX_ARM64;
+        Map<String, String> env = new HashMap<>();
+        env.put("XDG_DATA_HOME", "/user/foo/xgd");
+        File destination = ExecutableDestination.getDownloadDestination(platform, Optional.empty(), env);
+        assertEquals(
+                toUnixPath(destination),
+                "/user/foo/xgd/snyk/snyk-linux-arm64"
+        );
+    }
+
+    @Test
+    public void worksLinuxArm64NotSet() {
+        Platform platform = Platform.LINUX_ARM64;
+        Optional<Path> maybeHomeDir = Optional.of(Paths.get("/user/foo"));
+        Map<String, String> env = new HashMap<>();
+        File destination = ExecutableDestination.getDownloadDestination(platform, maybeHomeDir, env);
+        assertEquals(
+                toUnixPath(destination),
+                "/user/foo/.local/share/snyk/snyk-linux-arm64"
+        );
+    }
+
+    @Test
+    public void alpineThrowsIfXgdNotSetAndHomeDirNotSet() {
         Platform platform = Platform.LINUX_ALPINE;
         Optional<Path> missingHomeDir = Optional.empty(); // can't get home directory
         Map<String, String> env = new HashMap<>(); // no XDG_DATA_HOME

--- a/src/test/java/io/snyk/snyk_maven_plugin/download/PlatformTest.java
+++ b/src/test/java/io/snyk/snyk_maven_plugin/download/PlatformTest.java
@@ -9,28 +9,33 @@ public class PlatformTest {
 
     @Test
     public void shouldSupportMacOS() {
-        assertEquals(Platform.MAC_OS, Platform.detect("mac os x"));
-        assertEquals(Platform.MAC_OS, Platform.detect("darwin"));
+        assertEquals(Platform.MAC_OS, Platform.detect("mac os x", "x86_64"));
+        assertEquals(Platform.MAC_OS, Platform.detect("darwin", "x86_64"));
     }
 
     @Test
     public void shouldSupportLinux() {
-        assertEquals(Platform.LINUX, Platform.detect("linux"));
+        assertEquals(Platform.LINUX, Platform.detect("linux", "x86_64"));
+    }
+
+    @Test
+    public void shouldSupportLinuxArm64() {
+        assertEquals(Platform.LINUX_ARM64, Platform.detect("linux", "aarch64"));
     }
 
     @Test
     public void shouldSupportWindows() {
-        assertEquals(Platform.WINDOWS, Platform.detect("windows"));
+        assertEquals(Platform.WINDOWS, Platform.detect("windows", "x86_64"));
     }
 
     @Test
     public void shouldNotSupportUnknownPlatforms() {
-        assertThrows(IllegalArgumentException.class, () -> Platform.detect("nes64"));
+        assertThrows(IllegalArgumentException.class, () -> Platform.detect("nes64", "ppc64"));
     }
 
     @Test
     public void shouldIgnoreLetterCasing() {
-        assertEquals(Platform.MAC_OS, Platform.detect("MaC Os X"));
+        assertEquals(Platform.MAC_OS, Platform.detect("MaC Os X", "x86_64"));
     }
 
 }


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk-maven-plugin/blob/master/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

 #### What does this PR do?

Snyk offers a pre-built binary for Linux Arm64. One of the use-cases for this is running Linux containers on M1/M2 Apple laptops, specifically with 'linux/arm64/v8' architecture. This change allows the Snyk Maven plugin to detect the appropriate architecture and download the correct binary.

Without this change, the error received is `#17 13.87 [ERROR] qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory`, while `uname -m` shows `aarch64`.

I am not fully sure about the state of GitHub Actions tests, they seem to be broken for the past two months. The `surefire` tests are passing, and the plugin has been tested to work correctly in a local test context.

 #### Where should the reviewer start?

 #### How should this be manually tested?

 #### Any background context you want to provide?

 #### What are the relevant tickets?

 #### Screenshots

 #### Additional questions
